### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,9 +7,9 @@
 ADS1220RTD	KEYWORD1
 rtdInitialize	KEYWORD2
 offsetCalibration	KEYWORD2
-reset			KEYWORD2
-getRTDBytes		KEYWORD2
-getResistance		KEYWORD2
-getTemperatureC		KEYWORD2
-getTemperatureF		KEYWORD2
+reset	KEYWORD2
+getRTDBytes	KEYWORD2
+getResistance	KEYWORD2
+getTemperatureC	KEYWORD2
+getTemperatureF	KEYWORD2
 changeSlaveAddress	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords